### PR TITLE
[[ Bug 22100 ]] Ensure x86_64 is a synonym of x86-64

### DIFF
--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -761,7 +761,7 @@ private function __ArchitectureSynonyms pArchitecture
       case "x86-32"
          return pArchitecture,"x86,i386"
       case "x86-64"
-         return pArchitecture,"x64"
+         return pArchitecture,"x64,x86_64"
    end switch
    
    return pArchitecture


### PR DESCRIPTION
This patch fixes an issue where Windows externals suffixed by x86_64 were not 
grouped with other architectures.